### PR TITLE
Pass connecting time exceptions into the client observer

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -58,6 +58,10 @@ class Client extends Observable
 
         $request = $client->request('GET', $this->url, $flatHeaders, '1.1');
 
+        $request->on('error', function ($error) use ($clientObserver) {
+            $clientObserver->onError($error);
+        });
+
         $request->on('response', function (Response $response, Request $request) use ($flatHeaders, $cNegotiator, $nRequest, $clientObserver) {
             if ($response->getCode() !== 101) {
                 throw new \Exception('Unexpected response code ' . $response->getCode());

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rx\Websocket\Test;
+
+use React\EventLoop\Factory;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorBeforeRequest()
+    {
+        $loop = Factory::create();
+
+        $client = new \Rx\Websocket\Client('ws://127.0.0.1:12340/', false, [], $loop);
+
+        $errored = false;
+
+        $client->subscribe(
+            null,
+            function ($err) use (&$errored) {
+                $errored = true;
+            }
+        );
+
+        $loop->run();
+
+        $this->assertTrue($errored);
+    }
+}


### PR DESCRIPTION
Ran into this issue while trying to connect without a network connection and didn't get an connection failed exception