### PR TITLE
Forward compatibility with voryx/event-loop 3.0 and while supporting 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require": {
         "react/http": "^0.7.3 | ^0.8",
         "react/http-client": "^0.5.3",
-        "voryx/event-loop": "^2.0.2",
+        "voryx/event-loop": "^3.0 || ^2.0.2",
         "ratchet/rfc6455": "^0.2.2",
         "reactivex/rxphp": "^2.0.1"
     },


### PR DESCRIPTION
As promised at https://github.com/voryx/event-loop/pull/1#issuecomment-382123772 here is the PR that updates this package to support voryx/event-loop 3.0 and 2.0.