### PR TITLE
PHP 8.3 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         php:
+          - 8.3
+          - 8.2
           - 8.1
           - 8.0
           - 7.4
           - 7.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - 8.1
           - 8.0
           - 7.4
-          - 7.3
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,9 @@
     },
     "require": {
         "react/http": "1.5.* | 1.6.* | 1.7.* | 1.8.*",
-        "voryx/event-loop": "^3.0 || ^2.0.2",
         "ratchet/rfc6455": "^0.3",
-        "reactivex/rxphp": "^2.0.1"
+        "reactivex/rxphp": "^2.0.1",
+        "react/event-loop": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,6 @@
         "react/event-loop": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^9 | ^10"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,8 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<phpunit
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnFailure="false"
-        bootstrap="test/bootstrap.php">
-    <testsuites>
-        <testsuite name="RxWebsocket Test">
-            <directory>test/</directory>
-        </testsuite>
-    </testsuites>
-
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="test/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="RxWebsocket Test">
+      <directory>test/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,7 +46,7 @@ class Client extends Observable
         $this->url              = $url;
         $this->useMessageObject = $useMessageObject;
         $this->subProtocols     = $subProtocols;
-        $this->loop             = $loop ?: \EventLoop\getLoop();
+        $this->loop             = $loop ?: \React\EventLoop\Loop::get();
         $this->connector        = $connector;
         $this->keepAlive        = $keepAlive;
         $this->headers          = $headers;

--- a/src/MessageSubject.php
+++ b/src/MessageSubject.php
@@ -107,8 +107,8 @@ class MessageSubject extends Subject
             ->merge($keepAliveObs)
             ->subscribe(
                 [$messageBuffer, 'onData'],
-                [$this, 'parent::onError'],
-                [$this, 'parent::onCompleted']
+                function (\Throwable $e) { parent::onError($e); },
+                function () { parent::onCompleted(); }
             );
 
         $this->subProtocol = $subProtocol;

--- a/src/Server.php
+++ b/src/Server.php
@@ -35,7 +35,7 @@ class Server extends Observable
         $this->bindAddress      = $bindAddressOrPort;
         $this->useMessageObject = $useMessageObject;
         $this->subProtocols     = $subProtocols;
-        $this->loop             = $loop ?: \EventLoop\getLoop();
+        $this->loop             = $loop ?: \React\EventLoop\Loop::get();
         $this->keepAlive        = $keepAlive;
     }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -38,7 +38,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $connection
             ->method('write')
-            ->with($this->callback(function($data) use (&$writtenData) { $writtenData .= $data; }))
+            ->with($this->callback(function($data) use (&$writtenData) { $writtenData .= $data; return true;}))
             ->willReturn(true);
 
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -2,6 +2,7 @@
 
 namespace Rx\Websocket\Test;
 
+use React\EventLoop\Loop;
 use function EventLoop\addTimer;
 use function EventLoop\getLoop;
 use Rx\Websocket\Client;
@@ -16,11 +17,11 @@ class ServerTest extends TestCase
 
         $serverDisp = $server->subscribe();
 
-        addTimer(0.1, function () use ($serverDisp) {
+        Loop::addTimer(0.1, function () use ($serverDisp) {
             $serverDisp->dispose();
         });
 
-        getLoop()->run();
+        Loop::get()->run();
 
         // we are making sure it is not hanging - if it gets here it worked
         $this->assertTrue(true);
@@ -38,7 +39,7 @@ class ServerTest extends TestCase
 
         $value = null;
 
-        addTimer(0.1, function () use (&$value) {
+        Loop::addTimer(0.1, function () use (&$value) {
             $client = new Client('ws://127.0.0.1:1236');
             $client
                 ->flatMap(function (MessageSubject $ms) {
@@ -52,7 +53,7 @@ class ServerTest extends TestCase
                 });
         });
 
-        getLoop()->run();
+        Loop::get()->run();
 
         $this->assertEquals('olleH', $value);
     }

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -25,7 +25,7 @@ class TestCase extends FunctionalTestCase
 
         foreach ($props as $prop) {
             $prop->setAccessible(true);
-            $prop->setValue(null);
+            $prop->setValue($prop, null);
             $prop->setAccessible(false);
         }
     }

--- a/test/ab/clientRunner.php
+++ b/test/ab/clientRunner.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 const AGENT = "Websocket/0.0.0";
 
-echo "Using " . get_class(\EventLoop\getLoop()) . "\n";
+echo "Using " . get_class(\React\EventLoop\Loop::get()) . "\n";
 
 $runReports = function () {
     echo "Generating report.\n";
@@ -60,7 +60,7 @@ $runIndividualTest = function ($case, $timeout = 60000) {
         },
         function () use ($case, $deferred) {
             echo "Finished " . $case . "\n";
-            $deferred->resolve();
+            $deferred->resolve(null);
         }
     );
 
@@ -77,7 +77,7 @@ $runTests = function ($testCount) use ($runIndividualTest, $runReports) {
     $runNextCase = function () use (&$i, &$runNextCase, $testCount, $deferred, $runIndividualTest) {
         $i++;
         if ($i > $testCount) {
-            $deferred->resolve();
+            $deferred->resolve(null);
             return;
         }
         $runIndividualTest($i, 60000)->then(function ($result) use ($runIndividualTest, &$i) {

--- a/test/ab/testServer.php
+++ b/test/ab/testServer.php
@@ -4,7 +4,7 @@ use Rx\Observable;
 
 require_once __DIR__ . '/../bootstrap.php';
 
-$timerObservable = Observable::emptyObservable();
+$timerObservable = Observable::empty();
 
 if ($argc > 1 && is_numeric($argv[1])) {
     echo "Setting test server to stop in " . $argv[1] . " seconds.\n";

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -16,3 +16,5 @@ foreach ($files as $file) {
         break;
     }
 }
+
+Rx\Scheduler::setDefaultFactory(function () { return new \Rx\Scheduler\EventLoopScheduler(\React\EventLoop\Loop::get()); });


### PR DESCRIPTION
- Fixes PHP 8.3 incompatibilities
- Drop testing on PHP versions lower than 7.4
- Drop voryx/event-loop now that there is a react/event-loop global